### PR TITLE
Revive the batch deleter job

### DIFF
--- a/lib/cdmbl/batch_deleter.rb
+++ b/lib/cdmbl/batch_deleter.rb
@@ -3,21 +3,21 @@ module CDMBL
     attr_reader :prefix,
                 :start,
                 :batch_size,
-                :oai_client,
+                :oai_url,
                 :solr_client,
                 :oai_deletables_klass,
                 :notification_callback
     def initialize(prefix: '',
                    start: 0,
                    batch_size: 10,
-                   oai_client: :missing_oai_client,
+                   oai_url:,
                    solr_client: :missing_solr_client,
                    oai_deletables_klass: OaiDeletables,
                    notification_callback: CDMBL::BatchDeletedCallback)
       @prefix               = prefix
       @start                = start
       @batch_size           = batch_size
-      @oai_client           = oai_client
+      @oai_url              = oai_url
       @solr_client          = solr_client
       @oai_deletables_klass = oai_deletables_klass
       @notification_callback = notification_callback
@@ -39,7 +39,7 @@ module CDMBL
     def deletables
       @deletables ||= oai_deletables_klass.new(
         identifiers: ids,
-        oai_client: oai_client,
+        oai_url: oai_url,
         prefix: prefix
       ).deletables
     end

--- a/lib/cdmbl/batch_deleter.rb
+++ b/lib/cdmbl/batch_deleter.rb
@@ -5,48 +5,65 @@ module CDMBL
                 :batch_size,
                 :oai_client,
                 :solr_client,
-                :oai_deletables_klass
+                :oai_deletables_klass,
+                :notification_callback
     def initialize(prefix: '',
                    start: 0,
                    batch_size: 10,
                    oai_client: :missing_oai_client,
                    solr_client: :missing_solr_client,
-                   oai_deletables_klass: OaiDeletables)
+                   oai_deletables_klass: OaiDeletables,
+                   notification_callback: CDMBL::BatchDeletedCallback)
       @prefix               = prefix
       @start                = start
       @batch_size           = batch_size
       @oai_client           = oai_client
       @solr_client          = solr_client
       @oai_deletables_klass = oai_deletables_klass
+      @notification_callback = notification_callback
     end
 
     def delete!
       solr_client.delete deletables
+      notification_callback.call!(self)
     end
 
     def last_batch?
-      start + batch_size >= num_found
+      next_start >= num_found
+    end
+
+    def next_start
+      start + batch_size
     end
 
     def deletables
-      @deletables ||= oai_deletables_klass.new(identifiers: ids,
-                                               oai_client: oai_client,
-                                               prefix: prefix).deletables
+      @deletables ||= oai_deletables_klass.new(
+        identifiers: ids,
+        oai_client: oai_client,
+        prefix: prefix
+      ).deletables
     end
 
     private
 
-
     def ids
-      results.fetch('response', {}).fetch('docs', {}).map { |doc| doc['id'] }
+      results
+        .fetch('response', {})
+        .fetch('docs', {})
+        .map { |doc| doc['id'] }
     end
 
     def num_found
-      results.fetch('response', {}).fetch('numFound', 0)
+      results
+        .fetch('response', {})
+        .fetch('numFound', 0)
     end
 
     def results
-      @results ||= solr_client.ids(start: start)
+      @results ||= solr_client.ids(
+        start: start,
+        rows: batch_size
+      )
     end
   end
 end

--- a/lib/cdmbl/batch_deleter_worker.rb
+++ b/lib/cdmbl/batch_deleter_worker.rb
@@ -2,13 +2,14 @@ require 'sidekiq'
 module CDMBL
   class BatchDeleterWorker
     include Sidekiq::Worker
-    attr_reader :start, :prefix, :oai_url, :solr_url
-    attr_writer :batch_deleter_klass, :oai_client, :solr_client
-    def perform(start = 0, prefix = '', oai_url = '', solr_url = '')
-      @start    = start
-      @prefix   = prefix
-      @oai_url  = oai_url
-      @solr_url = solr_url
+    attr_reader :start, :batch_size, :prefix, :oai_url, :solr_url
+    attr_writer :batch_deleter_klass, :job_complete_notification, :oai_client, :solr_client
+    def perform(start = 0, batch_size = 10, prefix = '', oai_url = '', solr_url = '')
+      @start      = start
+      @batch_size = batch_size
+      @prefix     = prefix
+      @oai_url    = oai_url
+      @solr_url   = solr_url
       delete!
       batch_deleter
     end
@@ -19,19 +20,33 @@ module CDMBL
       @batch_deleter_klass ||= BatchDeleter
     end
 
+    def job_complete_notification
+      @job_complete_notification ||= CDMBL::BatchDeleteJobCompletedCallback
+    end
+
     def delete!
       batch_deleter.delete!
-      unless batch_deleter.last_batch?
-        BatchDeleterWorker.perform_async start + 1, prefix, oai_url, solr_url
+      if batch_deleter.last_batch?
+        job_complete_notification.call!
+      else
+        BatchDeleterWorker.perform_async(
+          batch_deleter.next_start,
+          batch_size,
+          prefix,
+          oai_url,
+          solr_url
+        )
       end
     end
 
     def batch_deleter
-      @batch_deleter ||=
-        batch_deleter_klass.new(start: start,
-                                prefix: prefix,
-                                solr_client: solr_client,
-                                oai_client: oai_client)
+      @batch_deleter ||= batch_deleter_klass.new(
+        start: start,
+        batch_size: batch_size,
+        prefix: prefix,
+        solr_client: solr_client,
+        oai_client: oai_client
+      )
     end
 
     def solr_client

--- a/lib/cdmbl/batch_deleter_worker.rb
+++ b/lib/cdmbl/batch_deleter_worker.rb
@@ -1,9 +1,11 @@
 require 'sidekiq'
+
 module CDMBL
   class BatchDeleterWorker
     include Sidekiq::Worker
     attr_reader :start, :batch_size, :prefix, :oai_url, :solr_url
-    attr_writer :batch_deleter_klass, :job_complete_notification, :oai_client, :solr_client
+    attr_writer :batch_deleter_klass, :job_complete_notification, :solr_client
+
     def perform(start = 0, batch_size = 10, prefix = '', oai_url = '', solr_url = '')
       @start      = start
       @batch_size = batch_size
@@ -45,16 +47,12 @@ module CDMBL
         batch_size: batch_size,
         prefix: prefix,
         solr_client: solr_client,
-        oai_client: oai_client
+        oai_url: oai_url
       )
     end
 
     def solr_client
       @solr_client ||= CDMBL::Solr.new(url: solr_url)
-    end
-
-    def oai_client
-      @oai_client ||= OaiClient.new base_url: oai_url
     end
   end
 end

--- a/lib/cdmbl/default_completed_callback.rb
+++ b/lib/cdmbl/default_completed_callback.rb
@@ -1,7 +1,7 @@
 module CDMBL
   # An example callback
   class DefaultCompletedCallback
-    def self.call!(solr_client)
+    def self.call!(*)
       puts "A callback task"
     end
   end

--- a/lib/cdmbl/default_solr.rb
+++ b/lib/cdmbl/default_solr.rb
@@ -9,13 +9,14 @@ module CDMBL
       @client = client
     end
 
-    def ids(start: 0)
+    def ids(start: 0, rows: 10)
       connection.get('select',
-        :params => { :q => '*:*',
-          :defType => 'edismax',
-          :fl => '',
-          :rows => 10,
-          :start => start
+        params: {
+          q: '*:*',
+          defType: 'edismax',
+          fl: '',
+          rows: rows,
+          start: start
         }
       )
     end

--- a/lib/cdmbl/hooks.rb
+++ b/lib/cdmbl/hooks.rb
@@ -1,14 +1,15 @@
 module CDMBL
   def self.const_missing(name)
-    if name.to_s == 'Solr'
+    case name.to_s
+    when 'Solr'
       hook(pattern: name.to_s, default: DefaultSolr)
-    elsif name.to_s == 'CompletedCallback'
+    when 'CompletedCallback', 'BatchDeleteJobCompletedCallback', 'BatchDeletedCallback'
       hook(pattern: name.to_s, default: DefaultCompletedCallback)
-    elsif name.to_s == 'OaiNotification'
+    when 'OaiNotification'
       hook(pattern: name.to_s, default: DefaultOaiNotification)
-    elsif name.to_s == 'LoaderNotification'
+    when 'LoaderNotification'
       hook(pattern: name.to_s, default: DefaultLoaderNotification)
-    elsif name.to_s == 'CdmNotification'
+    when 'CdmNotification'
       hook(pattern: name.to_s, default: DefaultCdmNotification)
     end
   end

--- a/lib/cdmbl/oai_client.rb
+++ b/lib/cdmbl/oai_client.rb
@@ -1,26 +1,41 @@
-
-require 'json'
 require 'http'
+
 module CDMBL
-    class OaiClient
-      attr_reader :base_url, :client
-      def initialize(base_url: '', client: HTTP)
-        @base_url    = base_url
-        @client = client
-      end
-
-      def request(query)
-        hashify get("#{base_url}?#{query}")
-      end
-
-      private
-
-      def get(url)
-        client.get(url).to_s
-      end
-
-      def hashify(xml)
-        Hash.from_xml(xml)
+  class OaiClient
+    class << self
+      def persistent(oai_url, &block)
+        uri = URI(oai_url)
+        client = HTTP.persistent(
+          uri.class.build(
+            host: uri.host,
+            port: uri.port
+          ).to_s
+        )
+        block.call(new(base_url: uri.path, client: client))
+      ensure
+        client.close
       end
     end
+
+    attr_reader :base_url, :client
+
+    def initialize(base_url: '', client: HTTP)
+      @base_url = base_url
+      @client = client
+    end
+
+    def request(query)
+      hashify get("#{base_url}?#{query}")
+    end
+
+    private
+
+    def get(url)
+      client.get(url).to_s
+    end
+
+    def hashify(xml)
+      Hash.from_xml(xml)
+    end
+  end
 end

--- a/lib/cdmbl/oai_deletables.rb
+++ b/lib/cdmbl/oai_deletables.rb
@@ -1,44 +1,33 @@
-require 'sidekiq'
 module CDMBL
   class OaiDeletables
-    attr_reader :identifiers, :oai_record_klass, :oai_client, :prefix
+    attr_reader :identifiers, :oai_record_klass, :oai_url, :prefix
+
     def initialize(identifiers: [],
                    prefix: '',
-                   oai_client: OaiClient.new,
+                   oai_url:,
                    oai_record_klass: OaiGetRecord)
-      @identifiers       = identifiers
-      @prefix            = prefix
-      @oai_client        = oai_client
-      @oai_record_klass  = oai_record_klass
+      @identifiers      = identifiers
+      @prefix           = prefix
+      @oai_url          = oai_url
+      @oai_record_klass = oai_record_klass
     end
 
     def deletables
-      identifiers.select do |id|
-        record_missing? to_oai_id(id)
+      OaiClient.persistent(oai_url) do |oai_client|
+        identifiers.select do |id|
+          !oai_record_klass.new(
+            oai_client: oai_client,
+            identifier: to_oai_id(id)
+          ).record_exists?
+        end
       end
     end
 
     private
 
     def to_oai_id(id)
-      "#{prefix}#{collection(id)}/#{id(id)}"
-    end
-
-    def id(id)
-      id_parts(id).last
-    end
-
-    def collection(id)
-      id_parts(id).first
-    end
-
-    def id_parts(id)
-      id.split(':')
-    end
-
-    def record_missing?(identifier)
-      !oai_record_klass.new(oai_client: oai_client,
-                           identifier: identifier).record_exists?
+      collection, id = id.split(':')
+      "#{prefix}#{collection}/#{id}"
     end
   end
 end

--- a/test/batch_deleter_test.rb
+++ b/test/batch_deleter_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 module CDMBL
   describe BatchDeleter do
-    let(:oai_client) { Minitest::Mock.new }
     let(:solr_client) { Minitest::Mock.new }
     let(:oai_deletables_klass) { Minitest::Mock.new }
     let(:oai_deletables_klass_object) { Minitest::Mock.new }
@@ -31,7 +30,7 @@ module CDMBL
           {
             identifiers: solr_docs,
             prefix: prefix,
-            oai_client: oai_client
+            oai_url: oai_url
           }
         ]
       )
@@ -42,7 +41,7 @@ module CDMBL
         prefix: prefix,
         start: 42,
         batch_size: 21,
-        oai_client: oai_client,
+        oai_url: oai_url,
         solr_client: solr_client,
         oai_deletables_klass: oai_deletables_klass,
         notification_callback: notification_callback
@@ -58,7 +57,7 @@ module CDMBL
     it 'responds with deletable records' do
       result = BatchDeleter.new(
         solr_client: CDMBL::Solr.new(url: solr_url),
-        oai_client: OaiClient.new(base_url: oai_url),
+        oai_url: oai_url,
         prefix: prefix
       ).deletables
       _(result).must_equal(["bad:ID"])
@@ -68,7 +67,7 @@ module CDMBL
       it 'signals the last batch' do
         result = BatchDeleter.new(
           solr_client: CDMBL::Solr.new(url: solr_url),
-          oai_client: OaiClient.new(base_url: oai_url),
+          oai_url: oai_url,
           prefix: prefix
         ).last_batch?
         _(result).must_equal(true)
@@ -80,7 +79,7 @@ module CDMBL
         result = BatchDeleter.new(
           batch_size: 1,
           solr_client: CDMBL::Solr.new(url: solr_url),
-          oai_client: OaiClient.new(base_url: oai_url),
+          oai_url: oai_url,
           prefix: prefix
         ).last_batch?
         _(result).must_equal(false)
@@ -91,7 +90,8 @@ module CDMBL
       it 'adds the batch_size to the current start' do
         deleter = BatchDeleter.new(
           start: 100,
-          batch_size: 100
+          batch_size: 100,
+          oai_url: oai_url
         )
         _(deleter.next_start).must_equal(200)
       end

--- a/test/batch_deleter_test.rb
+++ b/test/batch_deleter_test.rb
@@ -6,15 +6,15 @@ module CDMBL
     let(:solr_client) { Minitest::Mock.new }
     let(:oai_deletables_klass) { Minitest::Mock.new }
     let(:oai_deletables_klass_object) { Minitest::Mock.new }
-    let(:solr_docs) { ['collection1:23' , 'collection1:24'] }
+    let(:notification_callback) { Minitest::Mock.new }
+    let(:solr_docs) { ['collection1:23', 'collection1:24'] }
     let(:prefix) { 'oai:blah:' }
     let(:solr_response) do
       {
-        'response' =>
-          {
-            'docs' => [{ 'id' => 'collection1:23' }, { 'id' => 'collection1:24' }],
-            'numFound' => 2,
-          }
+        'response' => {
+          'docs' => [{ 'id' => 'collection1:23' }, { 'id' => 'collection1:24' }],
+          'numFound' => 2,
+        }
       }
     end
 
@@ -23,27 +23,36 @@ module CDMBL
     let(:prefix) { 'oai:cdm16022.contentdm.oclc.org:' }
 
     it 'calls its collaborators' do
-      solr_client.expect :ids, solr_response, [{start: 0}]
-      oai_deletables_klass.expect :new,
-                                  oai_deletables_klass_object,
-                                  [
-                                    {
-                                      identifiers: solr_docs,
-                                      prefix: prefix,
-                                      oai_client: oai_client
-                                    }
-                                  ]
-      solr_client.expect :delete,
-                         nil,
-                         [['collection1:23']]
+      solr_client.expect :ids, solr_response, [{start: 42, rows: 21}]
+      oai_deletables_klass.expect(
+        :new,
+        oai_deletables_klass_object,
+        [
+          {
+            identifiers: solr_docs,
+            prefix: prefix,
+            oai_client: oai_client
+          }
+        ]
+      )
+      solr_client.expect(:delete, nil, [['collection1:23']])
       oai_deletables_klass_object.expect :deletables, ['collection1:23']
-      BatchDeleter.new(prefix: prefix,
-                       oai_client: oai_client,
-                       solr_client: solr_client,
-                       oai_deletables_klass: oai_deletables_klass).delete!
+
+      instance = BatchDeleter.new(
+        prefix: prefix,
+        start: 42,
+        batch_size: 21,
+        oai_client: oai_client,
+        solr_client: solr_client,
+        oai_deletables_klass: oai_deletables_klass,
+        notification_callback: notification_callback
+      )
+      notification_callback.expect :call!, nil, [instance]
+      instance.delete!
       solr_client.verify
       oai_deletables_klass.verify
       oai_deletables_klass_object.verify
+      notification_callback.verify
     end
 
     it 'responds with deletable records' do
@@ -65,6 +74,7 @@ module CDMBL
         _(result).must_equal(true)
       end
     end
+
     describe 'when more results from solr are present' do
       it 'does not signal the last batch' do
         result = BatchDeleter.new(
@@ -74,6 +84,16 @@ module CDMBL
           prefix: prefix
         ).last_batch?
         _(result).must_equal(false)
+      end
+    end
+
+    describe '#next_start' do
+      it 'adds the batch_size to the current start' do
+        deleter = BatchDeleter.new(
+          start: 100,
+          batch_size: 100
+        )
+        _(deleter.next_start).must_equal(200)
       end
     end
   end

--- a/test/batch_deleter_worker_test.rb
+++ b/test/batch_deleter_worker_test.rb
@@ -6,6 +6,7 @@ module CDMBL
   describe BatchDeleterWorker do
     let(:batch_deleter_klass) { Minitest::Mock.new }
     let(:batch_deleter_klass_object) { Minitest::Mock.new }
+    let(:job_complete_notification) { Minitest::Mock.new }
     let(:oai_client) { Minitest::Mock.new }
     let(:solr_client) { Minitest::Mock.new }
     let(:ids) { [{ collection: 'p16022coll44', id: '1' }, { collection: 'p16022coll17', id: '669' }] }
@@ -15,31 +16,60 @@ module CDMBL
 
     it 'works - a worker sanity check' do
       worker = BatchDeleterWorker.new
-      deletables = worker.perform(0, prefix, oai_url, solr_url).deletables
+      deletables = worker.perform(0, 10, prefix, oai_url, solr_url).deletables
       _(deletables).must_equal(["bad:ID"])
-      last_batch = worker.perform(0, prefix, oai_url, solr_url).last_batch?
+      last_batch = worker.perform(0, 10, prefix, oai_url, solr_url).last_batch?
       _(last_batch).must_equal(true)
     end
 
     it 'Collaborates with BatchDeleter' do
-      batch_deleter_klass.expect :new,
-                                 batch_deleter_klass_object,
-                                 [
-                                   {
-                                    :start => 0,
-                                    :prefix => 'oai:cdm16022.contentdm.oclc.org:',
-                                    :solr_client => solr_client,
-                                    :oai_client=> oai_client
-                                    }
-                                  ]
+      batch_deleter_klass.expect(
+        :new,
+        batch_deleter_klass_object,
+        [{
+          start: 0,
+          batch_size: 42,
+          prefix: 'oai:cdm16022.contentdm.oclc.org:',
+          solr_client: solr_client,
+          oai_client: oai_client
+        }]
+      )
       batch_deleter_klass_object.expect :delete!, nil, []
       batch_deleter_klass_object.expect :last_batch?, nil, []
+      batch_deleter_klass_object.expect :next_start, 42
       worker = BatchDeleterWorker.new
       worker.batch_deleter_klass = batch_deleter_klass
       worker.oai_client = oai_client
       worker.solr_client = solr_client
-      worker.perform(0, prefix, oai_url, solr_url)
+      worker.perform(0, 42, prefix, oai_url, solr_url)
       batch_deleter_klass.verify
+    end
+
+    it 'calls the callback after the last batch' do
+      batch_deleter_klass.expect(
+        :new,
+        batch_deleter_klass_object,
+        [{
+          start: 0,
+          batch_size: 42,
+          prefix: 'oai:cdm16022.contentdm.oclc.org:',
+          solr_client: solr_client,
+          oai_client: oai_client
+        }]
+      )
+      batch_deleter_klass_object.expect :delete!, nil
+      batch_deleter_klass_object.expect :last_batch?, true
+      job_complete_notification.expect :call!, nil
+
+      worker = BatchDeleterWorker.new
+      worker.batch_deleter_klass = batch_deleter_klass
+      worker.oai_client = oai_client
+      worker.solr_client = solr_client
+      worker.job_complete_notification = job_complete_notification
+
+      worker.perform(0, 42, prefix, oai_url, solr_url)
+
+      job_complete_notification.verify
     end
   end
 end

--- a/test/batch_deleter_worker_test.rb
+++ b/test/batch_deleter_worker_test.rb
@@ -7,7 +7,6 @@ module CDMBL
     let(:batch_deleter_klass) { Minitest::Mock.new }
     let(:batch_deleter_klass_object) { Minitest::Mock.new }
     let(:job_complete_notification) { Minitest::Mock.new }
-    let(:oai_client) { Minitest::Mock.new }
     let(:solr_client) { Minitest::Mock.new }
     let(:ids) { [{ collection: 'p16022coll44', id: '1' }, { collection: 'p16022coll17', id: '669' }] }
     let(:oai_url) { 'http://cdm16022.contentdm.oclc.org/oai/oai.php' }
@@ -31,7 +30,7 @@ module CDMBL
           batch_size: 42,
           prefix: 'oai:cdm16022.contentdm.oclc.org:',
           solr_client: solr_client,
-          oai_client: oai_client
+          oai_url: oai_url
         }]
       )
       batch_deleter_klass_object.expect :delete!, nil, []
@@ -39,7 +38,6 @@ module CDMBL
       batch_deleter_klass_object.expect :next_start, 42
       worker = BatchDeleterWorker.new
       worker.batch_deleter_klass = batch_deleter_klass
-      worker.oai_client = oai_client
       worker.solr_client = solr_client
       worker.perform(0, 42, prefix, oai_url, solr_url)
       batch_deleter_klass.verify
@@ -54,7 +52,7 @@ module CDMBL
           batch_size: 42,
           prefix: 'oai:cdm16022.contentdm.oclc.org:',
           solr_client: solr_client,
-          oai_client: oai_client
+          oai_url: oai_url
         }]
       )
       batch_deleter_klass_object.expect :delete!, nil
@@ -63,7 +61,6 @@ module CDMBL
 
       worker = BatchDeleterWorker.new
       worker.batch_deleter_klass = batch_deleter_klass
-      worker.oai_client = oai_client
       worker.solr_client = solr_client
       worker.job_complete_notification = job_complete_notification
 

--- a/test/default_solr_test.rb
+++ b/test/default_solr_test.rb
@@ -5,17 +5,61 @@ module CDMBL
     let(:connection) { Minitest::Mock.new }
 
     it 'establishes a connection' do
-      client.expect :connect, connection, [{url: "http://solr:8983/solr/some-core-here"}]
-      Solr.new(url: 'http://solr:8983/solr/some-core-here', client: client).connection
+      client.expect(
+        :connect,
+        connection,
+        [{url: "http://solr:8983/solr/some-core-here"}]
+      )
+      Solr.new(
+        url: 'http://solr:8983/solr/some-core-here',
+        client: client
+      ).connection
       client.verify
     end
 
     it 'persists data to solr' do
-      client.expect :connect, connection, [{url: "http://solr:8983/solr/some-core-here"}]
+      client.expect(
+        :connect,
+        connection,
+        [{url: "http://solr:8983/solr/some-core-here"}]
+      )
       connection.expect :add, 'blah', [[{id: "3sfsdf"}]]
       connection.expect :commit, nil
-      Solr.new(url: 'http://solr:8983/solr/some-core-here', client: client).add([{id: "3sfsdf"}])
+      Solr.new(
+        url: 'http://solr:8983/solr/some-core-here',
+        client: client
+      ).add([{id: "3sfsdf"}])
       client.verify
+    end
+
+    describe '#ids' do
+      it 'passes start and rows to the client' do
+        mock_results = []
+        client.expect(
+          :connect,
+          connection,
+          [{url: "http://solr:8983/solr/some-core-here"}]
+        )
+        connection.expect(:get, mock_results, [
+          'select',
+          {
+            params: {
+              q: '*:*',
+              defType: 'edismax',
+              fl: '',
+              rows: 2,
+              start: 1
+            }
+          }
+        ])
+        results = Solr.new(
+          url: 'http://solr:8983/solr/some-core-here',
+          client: client
+        ).ids(start: 1, rows: 2)
+        _(results).must_equal(mock_results)
+        client.verify
+        connection.verify
+      end
     end
   end
 end

--- a/test/oai_client_test.rb
+++ b/test/oai_client_test.rb
@@ -1,18 +1,54 @@
 require 'test_helper'
+
 module CDMBL
   describe OaiClient do
     let(:http_client) { Minitest::Mock.new }
-    let(:http_client_object) { Minitest::Mock.new }
-    let(:oai_client) do
-      OaiClient.new(base_url: 'http://example.come',
-                    client: http_client)
+
+    describe '#request' do
+      it 'makes a request' do
+        mock_response = Minitest::Mock.new
+        http_client.expect :get, mock_response, ['http://example.com/oai/oai.php?getRecord=blah:foo/1']
+        mock_response.expect :to_s, '<xml><foo>blah</foo></xml>'
+        oai_client = OaiClient.new(
+          base_url: 'http://example.com/oai/oai.php',
+          client: http_client
+        )
+        _(oai_client.request('getRecord=blah:foo/1')).must_equal({"xml"=>{"foo"=>"blah"}})
+        http_client.verify
+      end
     end
 
-    it 'makes a request' do
-      http_client.expect :get, http_client_object, ['http://example.come?getRecord=blah:foo/1']
-      http_client_object.expect :to_s, '<xml><foo>blah</foo></xml>'
-      _(oai_client.request('getRecord=blah:foo/1')).must_equal({"xml"=>{"foo"=>"blah"}})
-      http_client.verify
+    describe '.persistent' do
+      it 'uses a persistent connection for the duration of the block' do
+        mock_response_1 = Minitest::Mock.new
+        mock_response_2 = Minitest::Mock.new
+
+        http_client.expect(:get, mock_response_1, ['/oai/oai.php?getRecord=Bob:foo/1'])
+        http_client.expect(:get, mock_response_2, ['/oai/oai.php?getRecord=Loblaw:foo/2'])
+        http_client.expect(:close, nil)
+
+        mock_response_1.expect(:to_s, '<xml><foo>Bob</foo></xml>')
+        mock_response_2.expect(:to_s, '<xml><foo>Loblaw</foo></xml>')
+
+        responses = []
+
+        HTTP.stub(:persistent, -> (domain) {
+          assert_equal(domain, 'http://example.com')
+          http_client
+        }) do
+          OaiClient.persistent('http://example.com/oai/oai.php') do |client|
+            responses << client.request('getRecord=Bob:foo/1')
+            responses << client.request('getRecord=Loblaw:foo/2')
+          end
+        end
+
+        assert_equal({ 'xml' => { 'foo' => 'Bob' } }, responses[0])
+        assert_equal({ 'xml' => { 'foo' => 'Loblaw' } }, responses[1])
+
+        http_client.verify
+        mock_response_1.verify
+        mock_response_2.verify
+      end
     end
   end
 end

--- a/test/oai_deletables_test.rb
+++ b/test/oai_deletables_test.rb
@@ -1,28 +1,37 @@
 require 'test_helper'
+
 module CDMBL
   describe OaiDeletables do
     let(:oai_client) { Minitest::Mock.new }
     let(:oai_record_klass) { Minitest::Mock.new }
-    let(:oai_record_klass_object_1) { Minitest::Mock.new }
-    let(:oai_record_klass_object_2) { Minitest::Mock.new }
-    let(:oai_record_klass_object_3) { Minitest::Mock.new }
-    let(:oai_record_klass_object_4) { Minitest::Mock.new }
+    let(:oai_record_instance_1) { Minitest::Mock.new }
+    let(:oai_record_instance_2) { Minitest::Mock.new }
     let(:identifiers) { ['colleciton123:1', 'colleciton124:2'] }
 
+    describe '#deletables' do
+      it 'makes requests using a persistent connection' do
+        OaiClient.stub(:persistent, -> (domain, &block) {
+          assert_equal('https://contentdm.oclc.org/oai/oai.php', domain)
+          block.call(oai_client)
+        }) do
+          oai_record_klass.expect :new, oai_record_instance_1, [{ oai_client: oai_client, identifier: 'oai:blah:colleciton123/1' }]
+          oai_record_klass.expect :new, oai_record_instance_2, [{ oai_client: oai_client, identifier: 'oai:blah:colleciton124/2' }]
+          oai_record_instance_1.expect :record_exists?, true
+          oai_record_instance_2.expect :record_exists?, false
 
-    it 'makes a request' do
-      oai_record_klass.expect :new, oai_record_klass_object_1, [{:oai_client=> oai_client, :identifier=>'oai:blah:colleciton123/1'}]
-      oai_record_klass.expect :new, oai_record_klass_object_2, [{:oai_client=> oai_client, :identifier=>'oai:blah:colleciton124/2'}]
-      oai_record_klass_object_1.expect :record_exists?, true
-      oai_record_klass_object_2.expect :record_exists?, false
-      deletables = OaiDeletables.new(identifiers: identifiers,
-                        prefix: 'oai:blah:',
-                        oai_client: oai_client,
-                        oai_record_klass: oai_record_klass).deletables
-      _(deletables).must_equal ['colleciton124:2']
-      oai_record_klass.verify
-      oai_record_klass_object_1.verify
-      oai_record_klass_object_2.verify
+          deletables = OaiDeletables.new(
+            identifiers: identifiers,
+            prefix: 'oai:blah:',
+            oai_url: 'https://contentdm.oclc.org/oai/oai.php',
+            oai_record_klass: oai_record_klass
+          ).deletables
+
+          _(deletables).must_equal ['colleciton124:2']
+          oai_record_klass.verify
+          oai_record_instance_1.verify
+          oai_record_instance_2.verify
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR fixes a pagination issue in the BatchDeleter and extends OaiClient with persistent connection support to increase efficiency.

**Fix pagination issue with BatchDeleter**

Prior to this change, the pagination behavior of BatchDeleter was to
window over 10 records at a time, incrementing the `start` parameter by
one each time. The issue there was that we were making 10 requests to
each record in the entire collection (ramping up using the first 10
records). The pagination was working like this:

0, 1, 2, 3, 4, 5, 6, 7, 8, 9
1, 2, 3, 4, 5, 6, 7, 8, 9, 10
2, 3, 4, 5, 6, 7, 8, 9, 10, 11

and so on. With this change, we're correctly paginating through by
increasing the `start` offset by the (now configurable) `batch_size`.

**Use persistent connection when batching requests to CDM**

When running the BatchDeleteWorker, we'll end up making several batches
of requests to CONTENTdm's OAI endpoint. Each batch is handled by its
own Sidekiq worker, but for the duration of that job, we can utilize a
persistent connection to CONTENTdm rather than making a new one for each
request. This will save time and bandwidth as this job runs.