### PR TITLE
Allow pruning stale Solr records filtered by query

### DIFF
--- a/lib/cdmbl/batch_deleter.rb
+++ b/lib/cdmbl/batch_deleter.rb
@@ -4,6 +4,7 @@ module CDMBL
                 :start,
                 :batch_size,
                 :oai_url,
+                :solr_query,
                 :solr_client,
                 :oai_deletables_klass,
                 :notification_callback
@@ -11,6 +12,7 @@ module CDMBL
                    start: 0,
                    batch_size: 10,
                    oai_url:,
+                   solr_query: nil,
                    solr_client: :missing_solr_client,
                    oai_deletables_klass: OaiDeletables,
                    notification_callback: CDMBL::BatchDeletedCallback)
@@ -18,6 +20,7 @@ module CDMBL
       @start                = start
       @batch_size           = batch_size
       @oai_url              = oai_url
+      @solr_query           = solr_query
       @solr_client          = solr_client
       @oai_deletables_klass = oai_deletables_klass
       @notification_callback = notification_callback
@@ -60,10 +63,14 @@ module CDMBL
     end
 
     def results
-      @results ||= solr_client.ids(
-        start: start,
-        rows: batch_size
-      )
+      @results ||= begin
+        args = {
+          start: start,
+          rows: batch_size,
+          fq: solr_query
+        }.compact
+        solr_client.ids(args)
+      end
     end
   end
 end

--- a/lib/cdmbl/batch_deleter_worker.rb
+++ b/lib/cdmbl/batch_deleter_worker.rb
@@ -3,15 +3,16 @@ require 'sidekiq'
 module CDMBL
   class BatchDeleterWorker
     include Sidekiq::Worker
-    attr_reader :start, :batch_size, :prefix, :oai_url, :solr_url
+    attr_reader :start, :batch_size, :prefix, :oai_url, :solr_url, :solr_query
     attr_writer :batch_deleter_klass, :job_complete_notification, :solr_client
 
-    def perform(start = 0, batch_size = 10, prefix = '', oai_url = '', solr_url = '')
+    def perform(start = 0, batch_size = 10, prefix = '', oai_url = '', solr_url = '', solr_query = nil)
       @start      = start
       @batch_size = batch_size
       @prefix     = prefix
       @oai_url    = oai_url
       @solr_url   = solr_url
+      @solr_query = solr_query
       delete!
       batch_deleter
     end
@@ -36,19 +37,25 @@ module CDMBL
           batch_size,
           prefix,
           oai_url,
-          solr_url
+          solr_url,
+          solr_query
         )
       end
     end
 
     def batch_deleter
-      @batch_deleter ||= batch_deleter_klass.new(
-        start: start,
-        batch_size: batch_size,
-        prefix: prefix,
-        solr_client: solr_client,
-        oai_url: oai_url
-      )
+      @batch_deleter ||= begin
+        args = {
+          start: start,
+          batch_size: batch_size,
+          prefix: prefix,
+          solr_client: solr_client,
+          solr_query: solr_query,
+          oai_url: oai_url
+        }.compact
+
+        batch_deleter_klass.new(args)
+      end
     end
 
     def solr_client

--- a/lib/cdmbl/default_solr.rb
+++ b/lib/cdmbl/default_solr.rb
@@ -1,7 +1,7 @@
 require 'rsolr'
 
 module CDMBL
-  # Commnicate with Solr: add / delete stuff
+  # Communicate with Solr: add / delete stuff
   class DefaultSolr
     attr_reader :url, :client
     def initialize(url: 'http://localhost:8983/solr/core-here', client: RSolr)
@@ -9,16 +9,16 @@ module CDMBL
       @client = client
     end
 
-    def ids(start: 0, rows: 10)
-      connection.get('select',
-        params: {
-          q: '*:*',
-          defType: 'edismax',
-          fl: '',
-          rows: rows,
-          start: start
-        }
-      )
+    def ids(start: 0, rows: 10, fq: nil)
+      params = {
+        q: '*:*',
+        fq: fq,
+        defType: 'edismax',
+        fl: '',
+        rows: rows,
+        start: start
+      }.compact
+      connection.get('select', params: params)
     end
 
     def connection

--- a/test/batch_deleter_worker_test.rb
+++ b/test/batch_deleter_worker_test.rb
@@ -43,6 +43,29 @@ module CDMBL
       batch_deleter_klass.verify
     end
 
+    it 'provides BatchDeleter with the given solr_query if applicable' do
+      batch_deleter_klass.expect(
+        :new,
+        batch_deleter_klass_object,
+        [{
+          start: 0,
+          batch_size: 42,
+          prefix: 'oai:cdm16022.contentdm.oclc.org:',
+          solr_client: solr_client,
+          solr_query: 'setspec_ssi:otter',
+          oai_url: oai_url
+        }]
+      )
+      batch_deleter_klass_object.expect :delete!, nil, []
+      batch_deleter_klass_object.expect :last_batch?, nil, []
+      batch_deleter_klass_object.expect :next_start, 42
+      worker = BatchDeleterWorker.new
+      worker.batch_deleter_klass = batch_deleter_klass
+      worker.solr_client = solr_client
+      worker.perform(0, 42, prefix, oai_url, solr_url, 'setspec_ssi:otter')
+      batch_deleter_klass.verify
+    end
+
     it 'calls the callback after the last batch' do
       batch_deleter_klass.expect(
         :new,

--- a/test/default_solr_test.rb
+++ b/test/default_solr_test.rb
@@ -60,6 +60,35 @@ module CDMBL
         client.verify
         connection.verify
       end
+
+      it 'scopes the query when one is provided' do
+        mock_results = []
+        client.expect(
+          :connect,
+          connection,
+          [{url: "http://solr:8983/solr/some-core-here"}]
+        )
+        connection.expect(:get, mock_results, [
+          'select',
+          {
+            params: {
+              q: '*:*',
+              fq: 'setspec_ssi:otter',
+              defType: 'edismax',
+              fl: '',
+              rows: 10,
+              start: 0
+            }
+          }
+        ])
+        results = Solr.new(
+          url: 'http://solr:8983/solr/some-core-here',
+          client: client
+        ).ids(fq: 'setspec_ssi:otter')
+        _(results).must_equal(mock_results)
+        client.verify
+        connection.verify
+      end
     end
   end
 end


### PR DESCRIPTION
This will allow for pruning records by collection, or any other set of
criteria. We'll be able to pass a setspec to a rake task, or even add
this to the MDL UI at some point.

Addresses [MDL #145](https://github.com/Minitex/mdl_search/issues/145)